### PR TITLE
Fix "Setting" and "Changes"

### DIFF
--- a/wiki/forms.py
+++ b/wiki/forms.py
@@ -269,7 +269,7 @@ class PermissionsForm(PluginSettingsFormMixin, forms.ModelForm):
 
     owner_username = forms.CharField(required=False, label=_(u'Owner'),
                                      help_text=_(u'Enter the username of the owner.'))
-    group = forms.ModelChoiceField(models.Group.objects.all(), empty_label=_(u'(none)'),
+    group = forms.ModelChoiceField(models.Group.objects.all(), label=_(u'group'), empty_label=_(u'(none)'),
                                      required=False)
     if settings.USE_BOOTSTRAP_SELECT_WIDGET:
         group.widget= SelectWidgetBootstrap()

--- a/wiki/templates/wiki/includes/revision_info.html
+++ b/wiki/templates/wiki/includes/revision_info.html
@@ -7,13 +7,15 @@
 
 
 {% load wiki_tags i18n %}
+{% trans "anonymous (IP not logged)" as anonymous_not_logged %}
+{% trans "anonymous (IP logged)" as anonymous_logged %}
 {% if not revision.ip_address %}
-{% if not hidedate %}{{ revision.created }}{% endif %} {% if not hidenumber %}(#{{ revision.revision_number }}) {% trans "by" %}{% endif %} {% if revision.user %}{{ revision.user }}{% else %}{% if article|can_moderate:user %}{% trans "anonymous (IP not logged)" %}{% else %}{% trans "anonymous (IP logged)" %}{% endif %}{% endif %}
+{% if not hidedate %}{{ revision.created }}{% endif %} {% if not hidenumber %}(#{{ revision.revision_number }}) {% trans "by" %}{% endif %} {% if revision.user %}{{ revision.user }}{% else %}{% if article|can_moderate:user %}{{ anonymous_not_logged }}{% else %}{{anonymous_logged}}{% endif %}{% endif %}
 {% if revision == current_revision %}
   <strong>*</strong>
 {% endif %}
 {% else %}
-{% if not hidedate %}{{ revision.created }}{% endif %} {% if not hidenumber %}(#{{ revision.revision_number }}) {% trans "by" %}{% endif %} {% if revision.user %}{{ revision.user }}{% else %}{% if article|can_moderate:user %}{{ revision.ip_address|default:"anonymous (IP not logged)" }}{% else %}{% trans "anonymous (IP logged)" %}{% endif %}{% endif %}
+{% if not hidedate %}{{ revision.created }}{% endif %} {% if not hidenumber %}(#{{ revision.revision_number }}) {% trans "by" %}{% endif %} {% if revision.user %}{{ revision.user }}{% else %}{% if article|can_moderate:user %}{{ revision.ip_address|default:anonymous_not_logged }}{% else %}{{anonymous_logged}}{% endif %}{% endif %}
 {% if revision == current_revision %}
   <strong>*</strong>
 {% endif %}


### PR DESCRIPTION
translation of the field `group` in the "settings" tab 
and messages `"anonymous (IP not logged)", "anonymous (IP not logged)" ` in the "Changes" tab